### PR TITLE
Ensure compatibility with Django 4.1

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,10 +22,10 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install and run tox
         run: |
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.9]
-        django: [22,32,main]
+        python: [3.9,3.10]
+        django: [32,40,41,main]
 
     env:
       TOXENV: py${{ matrix.python }}-django${{ matrix.django }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,8 @@ Because the `AppConfig` has moved, this change is listed as a breaking change
 as some users may have explicitly defined the route to the `AppConfig` as part
 of their Django Settings `INSTALLED_APPS` configuration. The fix is to simply
 use the new location instead.
+
+---
+
+Version support for Django v2 and Python v3.7 has been deprecated. The official
+support is now for Django v3.2->4.1.x and Python v3.8->3.10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+CHANGELOG
+=========
+
+0.3.0 - 2022-12-13 (BREAKING)
+-----------------------------
+
+This version ensures the application can work under Django 4.1 by ensuring it
+abides by newer default location for the AppConfig. The AppConfig was
+previously defined in the `__init__.py` with the `default_app_config` parameter
+but this was deprecated long ago in favour of placement in `apps.py`.
+
+Because the `AppConfig` has moved, this change is listed as a breaking change
+as some users may have explicitly defined the route to the `AppConfig` as part
+of their Django Settings `INSTALLED_APPS` configuration. The fix is to simply
+use the new location instead.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Provides a light-touch Django integration with Stripe.
 We handle Stripe webhook security & persisting all events, while allowing your project to take care
 of the business logic.
 
-Requires PostgreSQL, Python 3.x & Django 3.x.
+Supports PostgreSQL, Python 3.8+ & Django 3.2+.
 
 ## Installation & Usage
 

--- a/django_stripe/__init__.py
+++ b/django_stripe/__init__.py
@@ -1,26 +1,7 @@
-import stripe
-from django.apps import AppConfig as DjangoAppConfig
+import django
 
 __version__ = "0.2.2"
 
-default_app_config = "django_stripe.AppConfig"
 
-
-class AppConfig(DjangoAppConfig):
-
-    name = "django_stripe"
-    verbose_name = "Stripe"
-
-    def ready(self) -> None:
-        from . import settings
-
-        # Stripe library setup
-        stripe.api_key = settings.SECRET_KEY
-        stripe.api_version = settings.API_VERSION
-
-        # Identify the plugin to Stripe
-        stripe.set_app_info(
-            "django-stripe-lite",
-            version=__version__,
-            url="https://github.com/yunojuno/django-stripe-lite",
-        )
+if django.VERSION < (3, 2):
+    default_app_config = "django_stripe.apps.AppConfig"

--- a/django_stripe/__init__.py
+++ b/django_stripe/__init__.py
@@ -1,7 +1,3 @@
 import django
 
-__version__ = "0.2.2"
-
-
-if django.VERSION < (3, 2):
-    default_app_config = "django_stripe.apps.AppConfig"
+__version__ = "0.3"

--- a/django_stripe/apps.py
+++ b/django_stripe/apps.py
@@ -1,0 +1,23 @@
+import stripe
+
+from django.apps import AppConfig as DjangoAppConfig
+
+
+class AppConfig(DjangoAppConfig):
+
+    name = "django_stripe"
+    verbose_name = "Stripe"
+
+    def ready(self) -> None:
+        from . import settings
+
+        # Stripe library setup
+        stripe.api_key = settings.SECRET_KEY
+        stripe.api_version = settings.API_VERSION
+
+        # Identify the plugin to Stripe
+        stripe.set_app_info(
+            "django-stripe-lite",
+            version=__version__,
+            url="https://github.com/yunojuno/django-stripe-lite",
+        )

--- a/django_stripe/migrations/0001_initial.py
+++ b/django_stripe/migrations/0001_initial.py
@@ -4,9 +4,6 @@ from django.db import migrations, models
 
 import django_stripe.db.fields
 
-from ..compat import JSONField
-
-
 class Migration(migrations.Migration):
 
     initial = True
@@ -51,7 +48,7 @@ class Migration(migrations.Migration):
                 ("event_type", models.CharField(max_length=100)),
                 (
                     "data",
-                    JSONField(
+                    models.JSONField(
                         help_text=(
                             "The contents of data.object, representing the object the "
                             "webhook event was triggered for."
@@ -65,7 +62,7 @@ class Migration(migrations.Migration):
                     "request_idempotency_key",
                     models.CharField(blank=True, max_length=255),
                 ),
-                ("headers", JSONField(blank=True)),
+                ("headers", models.JSONField(blank=True)),
                 (
                     "remote_ip",
                     models.GenericIPAddressField(

--- a/django_stripe/models/webhook_event.py
+++ b/django_stripe/models/webhook_event.py
@@ -7,7 +7,6 @@ import stripe
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
-from ..compat import JSONField
 from ..utils.request import get_client_ip
 from .base import StripeModel
 
@@ -91,7 +90,7 @@ class WebhookEvent(StripeModel):
 
     # Event-object related fields.
     event_type = models.CharField(max_length=100)
-    data = JSONField(
+    data = models.JSONField(
         help_text=_(
             "The contents of data.object, representing the object "
             "the webhook event was triggered for."
@@ -106,7 +105,7 @@ class WebhookEvent(StripeModel):
 
     # Inbound webhook request data that we store
     # for security monitoring purposes only.
-    headers = JSONField(blank=True)
+    headers = models.JSONField(blank=True)
     remote_ip = models.GenericIPAddressField(
         verbose_name=_("Remote IP"), help_text=_("IP address of the remote client.")
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 isolated_build = True
-envlist = fmt, lint, mypy, py{3.7,3.8,3.9}-django{22,30,31,32,main}
+envlist = fmt, lint, mypy, py{3.8,3.9,3.10}-django{32,40,41,main}
 
 [gh-actions]
 python =
-    3.7: fmt, lint, mypy, py37
     3.8: fmt, lint, mypy, py38
+    3.9: fmt, lint, mypy, py39
+    3.10: fmt, lint, mypy, py310
 
 [testenv]
 passenv =
@@ -19,10 +20,6 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django{22,30}: psycopg2-binary
-    django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,8 @@ deps =
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     djangomaster: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
## Summary


**Ensure compatibility with Django 4.1**

By moving the AppConfig to the correct location and deprecating usage of the `default_app_config` attribute to those versions of Django less than 3.2 when it was officially deprecated.

**Deprecate support for Python v3.7 & Django v2.x**

We only maintain support for newer versions.

