### PR TITLE
Patch 4.0.0 to fix apps.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,25 @@
 # CHANGELOG
 
-All notable changes to this project will be documented in this file.
+All changes to this project will be documented in this file.
+
+## 0.4.1 - 2022-12-13
+
+Fix the 0.4.0 release; somehow the apps.py code got reverted before merge and we
+did not notice. This ensures the AppConfig can be found by Django 4.1.
 
 ## 0.4.0 - 2022-12-13 (BREAKING)
 
-This version ensures the application can work under Django 4.1 by ensuring it abides by newer
-default location for the AppConfig. The AppConfig was previously defined in the `__init__.py` with
-the `default_app_config` parameter but this was deprecated long ago in favour of placement in
-`apps.py`.
+This version ensures the application can work under Django 4.1 by ensuring it
+abides by newer default location for the AppConfig. The AppConfig was previously
+defined in the `__init__.py` with the `default_app_config` parameter but this was
+deprecated long ago in favour of placement in `apps.py`.
 
-Because the `AppConfig` has moved, this change is listed as a breaking change as some users may have
-explicitly defined the route to the `AppConfig` as part of their Django Settings `INSTALLED_APPS`
-configuration. The fix is to simply use the new location instead.
+Because the `AppConfig` has moved, this change is listed as a breaking change as
+some users may have explicitly defined the route to the `AppConfig` as part of
+their Django Settings `INSTALLED_APPS` configuration. The fix is to simply use
+the new location instead.
 
 ---
 
-Version support for Django v2 -> 3.1 and Python v3.7 has been deprecated. The official support is
-now for Django v3.2->4.1.x and Python v3.8->3.11.
+Version support for Django v2 -> 3.1 and Python v3.7 has been deprecated. The
+official support is now for Django v3.2->4.1.x and Python v3.8->3.11.

--- a/django_stripe/__init__.py
+++ b/django_stripe/__init__.py
@@ -1,24 +1,3 @@
 import stripe
-from django.apps import AppConfig as DjangoAppConfig
 
-__version__ = "0.4.0"
-
-
-class AppConfig(DjangoAppConfig):
-
-    name = "django_stripe"
-    verbose_name = "Stripe"
-
-    def ready(self) -> None:
-        from . import settings
-
-        # Stripe library setup
-        stripe.api_key = settings.SECRET_KEY
-        stripe.api_version = settings.API_VERSION
-
-        # Identify the plugin to Stripe
-        stripe.set_app_info(
-            "django-stripe-lite",
-            version=__version__,
-            url="https://github.com/yunojuno/django-stripe-lite",
-        )
+__version__ = "0.4.1"

--- a/django_stripe/__init__.py
+++ b/django_stripe/__init__.py
@@ -1,3 +1,1 @@
-import stripe
-
 __version__ = "0.4.1"

--- a/django_stripe/apps.py
+++ b/django_stripe/apps.py
@@ -1,0 +1,24 @@
+import stripe
+
+import django_stripe
+from django.apps import AppConfig as DjangoAppConfig
+
+
+class AppConfig(DjangoAppConfig):
+
+    name = "django_stripe"
+    verbose_name = "Stripe"
+
+    def ready(self) -> None:
+        from . import settings
+
+        # Stripe library setup
+        stripe.api_key = settings.SECRET_KEY
+        stripe.api_version = settings.API_VERSION
+
+        # Identify the plugin to Stripe
+        stripe.set_app_info(
+            "django-stripe-lite",
+            version=django_stripe.__version__,
+            url="https://github.com/yunojuno/django-stripe-lite",
+        )

--- a/django_stripe/apps.py
+++ b/django_stripe/apps.py
@@ -1,7 +1,7 @@
 import stripe
+from django.apps import AppConfig as DjangoAppConfig
 
 import django_stripe
-from django.apps import AppConfig as DjangoAppConfig
 
 
 class AppConfig(DjangoAppConfig):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-stripe-lite"
-version = "0.4.0"
+version = "0.4.1"
 description = "A library to aid Django integration with Stripe."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]

--- a/tests/test_webhook_view.py
+++ b/tests/test_webhook_view.py
@@ -2,9 +2,10 @@ import json
 import time
 from unittest import mock
 
+import stripe
 import pytest
 
-from django_stripe import settings, stripe, webhooks
+from django_stripe import settings, webhooks
 from django_stripe.models import WebhookEvent
 
 


### PR DESCRIPTION
## Summary

Move the `AppConfig` to a location which will automatically be found by Django 3.2+.

We promised to do this as part of the `4.0.0` release but somehow I managed to revert the change that actually did it before merge. This fixes that.