### PR TITLE
Misc: Upgrade Stripe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All changes to this project will be documented in this file.
 
+## 0.5.0 - 2022-12-13
+
+Upgrade our dependency on Stripe from vs 2.x to 5.x
+
 ## 0.4.1 - 2022-12-13
 
 Fix the 0.4.0 release; somehow the apps.py code got reverted before merge and we

--- a/django_stripe/__init__.py
+++ b/django_stripe/__init__.py
@@ -5,4 +5,4 @@ __all__ = [
     "stripe"
 ]
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/django_stripe/__init__.py
+++ b/django_stripe/__init__.py
@@ -1,1 +1,8 @@
+import stripe
+
+__all__ = [
+    # Re-export Stripe for ease of use.
+    "stripe"
+]
+
 __version__ = "0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-stripe-lite"
-version = "0.4.1"
+version = "0.5.0"
 description = "A library to aid Django integration with Stripe."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ packages = [{ include = "django_stripe" }]
 [tool.poetry.dependencies]
 python = "^3.8"
 django = "^3.2 || ^4.0"
-stripe = "^2.76.0"
+stripe = "^5.0.0"
 
 [tool.poetry.dev-dependencies]
 black = "*"


### PR DESCRIPTION
## Summary

Upgrade Stripe dependency from v2 to v5.

Release 0.5.0
