### PR TITLE
Misc: Django 6.0 upgrades

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -60,13 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12"]
-        django: ["42", "50", "52", "main"]
-        exclude:
-          - python: "3.10"
-            django: "main"
-          - python: "3.11"
-            django: "main"
+        python: ["3.12", "3.13"]
+        django: ["52", "60", "main"]
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Provides a light-touch Django integration with Stripe.
 We handle Stripe webhook security & persisting all events, while allowing your project to take care
 of the business logic.
 
-Requires Python 3.8+ & Django 3.2+.
+Requires Python 3.12+ and Django 5.2-6.0.
 
 ## Installation & Usage
 

--- a/django_stripe/models/webhook_event.py
+++ b/django_stripe/models/webhook_event.py
@@ -38,7 +38,9 @@ class WebhookEventManager(models.Manager):
 
         stripe_request = event.get("request")
         request_id = (stripe_request.id or "") if stripe_request else ""
-        request_idempotency_key = (stripe_request.idempotency_key or "") if stripe_request else ""
+        request_idempotency_key = (
+            (stripe_request.idempotency_key or "") if stripe_request else ""
+        )
 
         return self.create(
             stripe_id=event.id,

--- a/django_stripe/models/webhook_event.py
+++ b/django_stripe/models/webhook_event.py
@@ -37,8 +37,8 @@ class WebhookEventManager(models.Manager):
         remote_ip = get_client_ip(request)
 
         stripe_request = event.get("request")
-        request_id = stripe_request.id or ""
-        request_idempotency_key = stripe_request.idempotency_key or ""
+        request_id = (stripe_request.id or "") if stripe_request else ""
+        request_idempotency_key = (stripe_request.idempotency_key or "") if stripe_request else ""
 
         return self.create(
             stripe_id=event.id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-stripe-lite"
-version = "0.7.0"
+version = "0.8.0"
 description = "A library to aid Django integration with Stripe."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -12,24 +12,22 @@ documentation = "https://github.com/yunojuno/django-stripe-lite"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "django_stripe" }]
 
 [tool.poetry.dependencies]
-python = "^3.10"
-django = "^4.2 || ^5.0 || ^5.2"
+python = "^3.12"
+django = ">=5.2,<7.0"
 stripe = "^5.0.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 coverage = "*"
 freezegun = "*"
 mypy = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [{ include = "django_stripe" }]
 [tool.poetry.dependencies]
 python = "^3.12"
 django = ">=5.2,<7.0"
-stripe = "^5.0.0"
+stripe = ">=5.0.0,<15.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,9 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.0/releases/
-    django42-py{38,39,310,311}
-    django50-py{310,311,312}
-    django52-py{310,311,312}
-    djangomain-py{312}
+    django52-py{312,313}
+    django60-py{312,313}
+    djangomain-py{312,313}
 
 [testenv]
 deps =
@@ -15,9 +13,8 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django42: Django>=4.2,<4.3
-    django50: Django>=5.0,<5.1
     django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
## Summary

This PR upgrades the package to support Django 6.0 and Python 3.13.

## Changes

### Added
  - ✅ Django 6.0 support
  - ✅ Python 3.12, 3.13 support

### Removed
  - ❌ Python 3.9, 3.10, 3.11 support (now requires Python 3.12+)
  - ❌ Django 4.2 and 5.0 support (now supports Django 5.2-6.0)